### PR TITLE
Mutant Year Zero update to v1.07

### DIFF
--- a/markdown/CheatTables/MutantYearZero_One3rd.CT
+++ b/markdown/CheatTables/MutantYearZero_One3rd.CT
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<CheatTable CheatEngineTableVersion="24">
+<CheatTable CheatEngineTableVersion="28">
   <CheatEntries>
     <CheatEntry>
       <ID>13503</ID>
-      <Description>"This table was made by One3rd for the Steam version of Mutant Year Zero: Road to Eden."</Description>
+      <Description>"This table was made by One3rd for the Steam version of Mutant Year Zero: Road to Eden v1.07."</Description>
       <LastState Value="" RealAddress="00000000"/>
       <Color>FF0000</Color>
       <GroupHeader>1</GroupHeader>
@@ -103,7 +103,7 @@
       <VariableType>Auto Assembler Script</VariableType>
       <AssemblerScript>[ENABLE]
 //alloc(newmem,256)
-alloc(newmem,2048,"ZoneUE4-Win64-Shipping.exe"+6593E8)
+alloc(newmem,2048,"ZoneUE4-Win64-Shipping.exe"+6D7F08)
 label(returnhere)
 label(exit)
 label(pCamera)
@@ -125,7 +125,7 @@ pCamera:
 dd 0
 //
 
-"ZoneUE4-Win64-Shipping.exe"+6593E8:
+"ZoneUE4-Win64-Shipping.exe"+6D7F08:
 jmp newmem
 nop
 
@@ -133,38 +133,40 @@ returnhere:
 
 [DISABLE]
 dealloc(newmem)
-"ZoneUE4-Win64-Shipping.exe"+6593E8:
+"ZoneUE4-Win64-Shipping.exe"+6D7F08:
 mov eax,[rdx+08]
 mov [rcx+08],eax
 unregistersymbol(pCamera)
 
 {
-// ORIGINAL CODE - INJECTION POINT: "ZoneUE4-Win64-Shipping.exe"+6593E8
+aobscanmodule(INJECT,ZoneUE4-Win64-Shipping.exe,ERROR: Could not find unique AOB, tried code "8B 42 08 89 41 08") // should be unique
+alloc(newmem,$1000,"ZoneUE4-Win64-Shipping.exe"+6D7F08)
+// ORIGINAL CODE - INJECTION POINT: "ZoneUE4-Win64-Shipping.exe"+6D7F08
 
-"ZoneUE4-Win64-Shipping.exe"+6593CD: CC                       -  int 3
-"ZoneUE4-Win64-Shipping.exe"+6593CE: CC                       -  int 3
-"ZoneUE4-Win64-Shipping.exe"+6593CF: CC                       -  int 3
-"ZoneUE4-Win64-Shipping.exe"+6593D0: 48 89 5C 24 08           -  mov [rsp+08],rbx
-"ZoneUE4-Win64-Shipping.exe"+6593D5: 57                       -  push rdi
-"ZoneUE4-Win64-Shipping.exe"+6593D6: 48 83 EC 20              -  sub rsp,20
-"ZoneUE4-Win64-Shipping.exe"+6593DA: F2 0F 10 02              -  movsd xmm0,[rdx]
-"ZoneUE4-Win64-Shipping.exe"+6593DE: 48 8B F9                 -  mov rdi,rcx
-"ZoneUE4-Win64-Shipping.exe"+6593E1: F2 0F 11 01              -  movsd [rcx],xmm0
-"ZoneUE4-Win64-Shipping.exe"+6593E5: 48 8B DA                 -  mov rbx,rdx
+"ZoneUE4-Win64-Shipping.exe"+6D7EED: CC                       -  int 3
+"ZoneUE4-Win64-Shipping.exe"+6D7EEE: CC                       -  int 3
+"ZoneUE4-Win64-Shipping.exe"+6D7EEF: CC                       -  int 3
+"ZoneUE4-Win64-Shipping.exe"+6D7EF0: 48 89 5C 24 08           -  mov [rsp+08],rbx
+"ZoneUE4-Win64-Shipping.exe"+6D7EF5: 57                       -  push rdi
+"ZoneUE4-Win64-Shipping.exe"+6D7EF6: 48 83 EC 20              -  sub rsp,20
+"ZoneUE4-Win64-Shipping.exe"+6D7EFA: F2 0F 10 02              -  movsd xmm0,[rdx]
+"ZoneUE4-Win64-Shipping.exe"+6D7EFE: 48 8B F9                 -  mov rdi,rcx
+"ZoneUE4-Win64-Shipping.exe"+6D7F01: F2 0F 11 01              -  movsd [rcx],xmm0
+"ZoneUE4-Win64-Shipping.exe"+6D7F05: 48 8B DA                 -  mov rbx,rdx
 // ---------- INJECTING HERE ----------
-"ZoneUE4-Win64-Shipping.exe"+6593E8: 8B 42 08                 -  mov eax,[rdx+08]
-"ZoneUE4-Win64-Shipping.exe"+6593EB: 89 41 08                 -  mov [rcx+08],eax
+"ZoneUE4-Win64-Shipping.exe"+6D7F08: 8B 42 08                 -  mov eax,[rdx+08]
+"ZoneUE4-Win64-Shipping.exe"+6D7F0B: 89 41 08                 -  mov [rcx+08],eax
 // ---------- DONE INJECTING  ----------
-"ZoneUE4-Win64-Shipping.exe"+6593EE: F2 0F 10 42 0C           -  movsd xmm0,[rdx+0C]
-"ZoneUE4-Win64-Shipping.exe"+6593F3: F2 0F 11 41 0C           -  movsd [rcx+0C],xmm0
-"ZoneUE4-Win64-Shipping.exe"+6593F8: 8B 42 14                 -  mov eax,[rdx+14]
-"ZoneUE4-Win64-Shipping.exe"+6593FB: 89 41 14                 -  mov [rcx+14],eax
-"ZoneUE4-Win64-Shipping.exe"+6593FE: 8B 42 18                 -  mov eax,[rdx+18]
-"ZoneUE4-Win64-Shipping.exe"+659401: 89 41 18                 -  mov [rcx+18],eax
-"ZoneUE4-Win64-Shipping.exe"+659404: 8B 42 1C                 -  mov eax,[rdx+1C]
-"ZoneUE4-Win64-Shipping.exe"+659407: 89 41 1C                 -  mov [rcx+1C],eax
-"ZoneUE4-Win64-Shipping.exe"+65940A: 8B 42 20                 -  mov eax,[rdx+20]
-"ZoneUE4-Win64-Shipping.exe"+65940D: 89 41 20                 -  mov [rcx+20],eax
+"ZoneUE4-Win64-Shipping.exe"+6D7F0E: F2 0F 10 42 0C           -  movsd xmm0,[rdx+0C]
+"ZoneUE4-Win64-Shipping.exe"+6D7F13: F2 0F 11 41 0C           -  movsd [rcx+0C],xmm0
+"ZoneUE4-Win64-Shipping.exe"+6D7F18: 8B 42 14                 -  mov eax,[rdx+14]
+"ZoneUE4-Win64-Shipping.exe"+6D7F1B: 89 41 14                 -  mov [rcx+14],eax
+"ZoneUE4-Win64-Shipping.exe"+6D7F1E: 8B 42 18                 -  mov eax,[rdx+18]
+"ZoneUE4-Win64-Shipping.exe"+6D7F21: 89 41 18                 -  mov [rcx+18],eax
+"ZoneUE4-Win64-Shipping.exe"+6D7F24: 8B 42 1C                 -  mov eax,[rdx+1C]
+"ZoneUE4-Win64-Shipping.exe"+6D7F27: 89 41 1C                 -  mov [rcx+1C],eax
+"ZoneUE4-Win64-Shipping.exe"+6D7F2A: 8B 42 20                 -  mov eax,[rdx+20]
+"ZoneUE4-Win64-Shipping.exe"+6D7F2D: 89 41 20                 -  mov [rcx+20],eax
 }
 </AssemblerScript>
       <Hotkeys>
@@ -590,19 +592,11 @@ unregistersymbol(pCamera)
         </CheatEntry>
       </CheatEntries>
     </CheatEntry>
-    <CheatEntry>
-      <ID>13505</ID>
-      <Description>"============================"</Description>
-      <LastState Value="" RealAddress="00000000"/>
-      <GroupHeader>1</GroupHeader>
-    </CheatEntry>
   </CheatEntries>
   <CheatCodes>
     <CodeEntry>
       <Description>Code :mov eax,[rdx+08] - z</Description>
-      <Address>13FED8B28</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>658B28</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+658B28</AddressString>
       <Before>
         <Byte>11</Byte>
         <Byte>01</Byte>
@@ -625,9 +619,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rcx+00000418]</Description>
-      <Address>140D4D225</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AFD225</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AFD225</AddressString>
       <Before>
         <Byte>00</Byte>
         <Byte>F2</Byte>
@@ -653,9 +645,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rcx+00000418]</Description>
-      <Address>140D49F40</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AF9F40</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AF9F40</AddressString>
       <Before>
         <Byte>CC</Byte>
         <Byte>CC</Byte>
@@ -681,9 +671,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov [rdi+00000418],eax</Description>
-      <Address>140D462CE</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AF62CE</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AF62CE</AddressString>
       <Before>
         <Byte>0F</Byte>
         <Byte>10</Byte>
@@ -709,9 +697,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rcx+00000418]</Description>
-      <Address>140D49F8C</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AF9F8C</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AF9F8C</AddressString>
       <Before>
         <Byte>00</Byte>
         <Byte>F2</Byte>
@@ -737,9 +723,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rdx+08] - Z-AXIS</Description>
-      <Address>13FED93E8</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>6593E8</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+6593E8</AddressString>
       <Before>
         <Byte>11</Byte>
         <Byte>01</Byte>
@@ -762,9 +746,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rcx+00000418]</Description>
-      <Address>14137FE95</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AFFE95</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AFFE95</AddressString>
       <Before>
         <Byte>00</Byte>
         <Byte>F2</Byte>
@@ -790,9 +772,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov eax,[rcx+00000418]</Description>
-      <Address>14137CBB0</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AFCBB0</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AFCBB0</AddressString>
       <Before>
         <Byte>CC</Byte>
         <Byte>CC</Byte>
@@ -818,9 +798,7 @@ unregistersymbol(pCamera)
     </CodeEntry>
     <CodeEntry>
       <Description>Code :mov [rdi+00000418],eax</Description>
-      <Address>141378D0E</Address>
-      <ModuleName>ZoneUE4-Win64-Shipping.exe</ModuleName>
-      <ModuleNameOffset>1AF8D0E</ModuleNameOffset>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1AF8D0E</AddressString>
       <Before>
         <Byte>0F</Byte>
         <Byte>10</Byte>
@@ -844,8 +822,448 @@ unregistersymbol(pCamera)
         <Byte>89</Byte>
       </After>
     </CodeEntry>
+    <CodeEntry>
+      <Description>Code :movss [rsi],xmm0 - DUX health? float</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1FC02A0</AddressString>
+      <Before>
+        <Byte>48</Byte>
+        <Byte>8B</Byte>
+        <Byte>5C</Byte>
+        <Byte>24</Byte>
+        <Byte>30</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>0F</Byte>
+        <Byte>11</Byte>
+        <Byte>06</Byte>
+      </Actual>
+      <After>
+        <Byte>48</Byte>
+        <Byte>8B</Byte>
+        <Byte>74</Byte>
+        <Byte>24</Byte>
+        <Byte>40</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov ecx,[rdx]</Description>
+      <AddressString>VCRUNTIME140.dll+C51B</AddressString>
+      <Before>
+        <Byte>0A</Byte>
+        <Byte>49</Byte>
+        <Byte>8B</Byte>
+        <Byte>CB</Byte>
+        <Byte>C3</Byte>
+      </Before>
+      <Actual>
+        <Byte>8B</Byte>
+        <Byte>0A</Byte>
+      </Actual>
+      <After>
+        <Byte>89</Byte>
+        <Byte>08</Byte>
+        <Byte>C3</Byte>
+        <Byte>8B</Byte>
+        <Byte>0A</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp dword ptr [rax+00000208],00 - dux hp (4bytes)</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+278102</AddressString>
+      <Before>
+        <Byte>83</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>83</Byte>
+        <Byte>B8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>48</Byte>
+        <Byte>83</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp [rax+00000208],r13d</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+289211</AddressString>
+      <Before>
+        <Byte>87</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>44</Byte>
+        <Byte>39</Byte>
+        <Byte>A8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>84</Byte>
+        <Byte>C0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp [rax+00000208],r13d</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+2893D6</AddressString>
+      <Before>
+        <Byte>87</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>44</Byte>
+        <Byte>39</Byte>
+        <Byte>A8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>84</Byte>
+        <Byte>C0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp dword ptr [rax+00000208],00</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+28B012</AddressString>
+      <Before>
+        <Byte>83</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>83</Byte>
+        <Byte>B8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>84</Byte>
+        <Byte>C0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp [rcx+00000208],r15d</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+2B1638</AddressString>
+      <Before>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>8D</Byte>
+        <Byte>42</Byte>
+        <Byte>01</Byte>
+      </Before>
+      <Actual>
+        <Byte>44</Byte>
+        <Byte>39</Byte>
+        <Byte>B9</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>4E</Byte>
+        <Byte>C2</Byte>
+        <Byte>8B</Byte>
+        <Byte>D0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov ecx,[rdx]</Description>
+      <AddressString>VCRUNTIME140.dll+C51B</AddressString>
+      <Before>
+        <Byte>0A</Byte>
+        <Byte>49</Byte>
+        <Byte>8B</Byte>
+        <Byte>CB</Byte>
+        <Byte>C3</Byte>
+      </Before>
+      <Actual>
+        <Byte>8B</Byte>
+        <Byte>0A</Byte>
+      </Actual>
+      <After>
+        <Byte>89</Byte>
+        <Byte>08</Byte>
+        <Byte>C3</Byte>
+        <Byte>8B</Byte>
+        <Byte>0A</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov eax,[rbx+00000208] - reads Dux health</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+233D4E</AddressString>
+      <Before>
+        <Byte>CF</Byte>
+        <Byte>89</Byte>
+        <Byte>44</Byte>
+        <Byte>24</Byte>
+        <Byte>28</Byte>
+      </Before>
+      <Actual>
+        <Byte>8B</Byte>
+        <Byte>83</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>89</Byte>
+        <Byte>45</Byte>
+        <Byte>83</Byte>
+        <Byte>8B</Byte>
+        <Byte>83</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp dword ptr [rax+00000208],00</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+3BC1D5</AddressString>
+      <Before>
+        <Byte>08</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>EB</Byte>
+        <Byte>0D</Byte>
+      </Before>
+      <Actual>
+        <Byte>83</Byte>
+        <Byte>B8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>8E</Byte>
+        <Byte>3F</Byte>
+        <Byte>08</Byte>
+        <Byte>00</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp dword ptr [rax+00000208],00</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+263BE0</AddressString>
+      <Before>
+        <Byte>83</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>83</Byte>
+        <Byte>B8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>84</Byte>
+        <Byte>C0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp [rax+00000208],ebx - writes Dux health</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+284179</AddressString>
+      <Before>
+        <Byte>87</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>98</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>0F</Byte>
+        <Byte>9F</Byte>
+        <Byte>C0</Byte>
+        <Byte>84</Byte>
+        <Byte>C0</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :cmp [rax+00000208],edi</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+2A2714</AddressString>
+      <Before>
+        <Byte>81</Byte>
+        <Byte>28</Byte>
+        <Byte>09</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>B8</Byte>
+        <Byte>08</Byte>
+        <Byte>02</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>7F</Byte>
+        <Byte>14</Byte>
+        <Byte>FF</Byte>
+        <Byte>83</Byte>
+        <Byte>CC</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov eax,[rdx+08] - new z</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+6D7F08</AddressString>
+      <Before>
+        <Byte>11</Byte>
+        <Byte>01</Byte>
+        <Byte>48</Byte>
+        <Byte>8B</Byte>
+        <Byte>DA</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>42</Byte>
+        <Byte>08</Byte>
+      </Actual>
+      <After>
+        <Byte>89</Byte>
+        <Byte>41</Byte>
+        <Byte>08</Byte>
+        <Byte>F2</Byte>
+        <Byte>0F</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov eax,[rcx+00000418]</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1DC03CF</AddressString>
+      <Before>
+        <Byte>00</Byte>
+        <Byte>F2</Byte>
+        <Byte>0F</Byte>
+        <Byte>11</Byte>
+        <Byte>07</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>81</Byte>
+        <Byte>18</Byte>
+        <Byte>04</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>89</Byte>
+        <Byte>47</Byte>
+        <Byte>08</Byte>
+        <Byte>F2</Byte>
+        <Byte>0F</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov eax,[rcx+00000418]</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1DBD350</AddressString>
+      <Before>
+        <Byte>CC</Byte>
+        <Byte>CC</Byte>
+        <Byte>CC</Byte>
+        <Byte>CC</Byte>
+        <Byte>CC</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>81</Byte>
+        <Byte>18</Byte>
+        <Byte>04</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>F2</Byte>
+        <Byte>0F</Byte>
+        <Byte>10</Byte>
+        <Byte>81</Byte>
+        <Byte>10</Byte>
+      </After>
+    </CodeEntry>
+    <CodeEntry>
+      <Description>Code :mov [rdi+00000418],eax</Description>
+      <AddressString>ZoneUE4-Win64-Shipping.exe+1DB956E</AddressString>
+      <Before>
+        <Byte>00</Byte>
+        <Byte>8B</Byte>
+        <Byte>44</Byte>
+        <Byte>24</Byte>
+        <Byte>48</Byte>
+      </Before>
+      <Actual>
+        <Byte>CC</Byte>
+        <Byte>87</Byte>
+        <Byte>18</Byte>
+        <Byte>04</Byte>
+        <Byte>00</Byte>
+        <Byte>00</Byte>
+      </Actual>
+      <After>
+        <Byte>F2</Byte>
+        <Byte>0F</Byte>
+        <Byte>10</Byte>
+        <Byte>44</Byte>
+        <Byte>24</Byte>
+      </After>
+    </CodeEntry>
   </CheatCodes>
   <UserdefinedSymbols>
+    <SymbolEntry>
+      <Name>memPointerTest</Name>
+      <Address>13E30000</Address>
+    </SymbolEntry>
     <SymbolEntry>
       <Name>coords</Name>
       <Address>159F0016</Address>
@@ -1006,14 +1424,14 @@ unregistersymbol(pCamera)
       <Name>LocalPlayerHkB</Name>
       <Address>008A214A</Address>
     </SymbolEntry>
-    <SymbolEntry>
-      <Name>pCamera</Name>
-      <Address>13F220029</Address>
-    </SymbolEntry>
   </UserdefinedSymbols>
   <Comments>1. HUD toggle using 3DMigoto is bundled with this CE table. Install the contents of the HUD Toggle Zip file to "..\Steam\steamapps\common\Mutant Year Zero\ZoneUE4\Binaries\Win64". 
 2. By default the [Caps Lock] key will toggle the pause menu HUD. You will need to be in the main menu (which conveniently pauses the game) and then press [Caps Lock] to disable the HUD. Press [Caps Lock] again to enable it.
 3. Hotsampling works with SRWE. Set the game to windowed fullscreen and change the resoltion with SRWE.
 4. Disable startup movies by going to "..\Steam\steamapps\common\Mutant Year Zero\ZoneUE4\Content\Movies" and renaming the .mp4 files.
+
+
+notes:
+z-axis : 1244.226318 - in 100 intervals of scroll wheel - 2144.226318
 </Comments>
 </CheatTable>


### PR DESCRIPTION
1. Updated Mutant Year Zero CE table to work with v1.07. Should now work with "Seed of Evil DLC".