### PR TITLE
Update banner image credit username on BG3 guide.

### DIFF
--- a/markdown/GameGuides/baldursgate3.md
+++ b/markdown/GameGuides/baldursgate3.md
@@ -1,4 +1,4 @@
-![Baldur's Gate 3](Images\baldursgate3_header.png "Shot by ashcorpdev"){.shadowed .autosize}
+![Baldur's Gate 3](Images\baldursgate3_header.png "Shot by ofseaandstars"){.shadowed .autosize}
 
 ## Summary
 


### PR DESCRIPTION
Quick update to the banner image credit to use my new username rather than my old one. Forgot to do it back when I changed my name.